### PR TITLE
use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -183,7 +183,7 @@ ind = annualmin(C)
 # @test mapclimgrid(annualmax(C), region = "Canada") == 1
 
 # NetCDF Extraction test
-filename = joinpath(Pkg.dir("ClimateTools"), "test", "data", "sresa1b_ncar_ccsm3-example.nc")
+filename = joinpath(dirname(@__FILE__), "data", "sresa1b_ncar_ccsm3-example.nc")
 # nc2julia(filename)
 C = nc2julia(filename, "tas", poly = [0. 0.])
 @test typeof(nc2julia(filename, "tas", poly = [0. 0.])) == ClimateTools.ClimGrid
@@ -206,7 +206,7 @@ timeRaw = floor(NetCDF.ncread(filename, "time"))
 @test C[5] == ""
 @test C[6] == "degrees_east"
 @test C[7] == "degrees_north"
-@test C[8] == joinpath(Pkg.dir("ClimateTools"), "test", "data", "sresa1b_ncar_ccsm3-example.nc")
+@test C[8] == joinpath(dirname(@__FILE__), "data", "sresa1b_ncar_ccsm3-example.nc")
 @test C[9] == "tas"
 @test annualmax(C)[9] == "annualmax"
 @test C[10] == "tas"


### PR DESCRIPTION
Pkg.dir is not correct if the package is installed elsewhere on LOAD_PATH