### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ os:
   - linux
   - osx
 julia:
-  - release
-  - nightly
   - 0.5
   - 0.6
+  - nightly
 matrix:
   #- PYTHON=python  # python 2.7
   #- PYTHON=python3 # python 3.5


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.5 so it should continue to be tested