### PR TITLE
Travis redundacy fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
 matrix:
   allow_failures:
     - julia: nightly
+branches:
+  only:
+    - master
 notifications:
   email: false
 # uncomment the following lines to override the default test script


### PR DESCRIPTION
This commit should prevent Travis from being triggered twice when opening a PR. Hopefully.